### PR TITLE
Universalize .bin scripts

### DIFF
--- a/.bin/labprog-funcs.sh
+++ b/.bin/labprog-funcs.sh
@@ -3,6 +3,8 @@ if  [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     exit 1
 fi
 
+source ${0%/*}/prog2home.sh
+
 up_tm() {
     cur=$(pwd -P)
     while [ ! -z $cur ] && [ ! -r "$cur/.tm" ]; do
@@ -12,7 +14,7 @@ up_tm() {
         chmod u+x "$cur/.tm"
         "$cur/.tm" "$@"
     else
-        echo "${0##*/}: errore: posizionarsi in una sottodirectory di '/workspace/esercitazioni'..." 2>&1
+        echo "${0##*/}: errore: posizionarsi in una sottodirectory di '$PROG2HOME'..." 2>&1
         return
     fi
 }

--- a/.bin/prog2home.sh
+++ b/.bin/prog2home.sh
@@ -1,0 +1,6 @@
+if  [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo 'this script must be sourced, not executed' 2>&1
+    exit 1
+fi
+
+PROG2HOME="/workspace/esercitazioni"

--- a/.bin/soluzione
+++ b/.bin/soluzione
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-LC_ALL=it_IT.UTF-8 /workspace/esercitazioni/.bin/sf run -qf "$@"
+LC_ALL=it_IT.UTF-8 ${0%/*}/sf run -qf "$@"

--- a/.bin/svolgi
+++ b/.bin/svolgi
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+source ${0%/*}/prog2home.sh
+
 if [ -z "$1" ]; then
     echo "svolgi: manca il parametro '<NOME_ESERCITAZIONE>/<MATRICOLA>'" >&2
     exit 1
 fi
 eval $(
-HOME="/workspace/esercitazioni/$(echo $1 | cut -d/ -f1)"
+HOME="$PROG2HOME/$(echo $1 | cut -d/ -f1)"
 cat <<EOF | python3 2>&1
 # -*- coding: utf-8 -*-
 from urllib.request import urlopen

--- a/.bin/verifica
+++ b/.bin/verifica
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-LC_ALL=it_IT.UTF-8 /workspace/esercitazioni/.bin/sf test -vf "$@"
+LC_ALL=it_IT.UTF-8 ${0%/*}/sf test -vf "$@"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,16 @@ siano correttamente installati e configurati i seguenti software:
 * Java Development Kit (versione 11, o superiore).
 
 Una volta accertato questo prerequisito, è sufficiente *clonare* questo
-repository, aggiungere la directory `.bin` in esso contenuta al *path* e quindi
-procedere nel modo descritto per l'uso su Gitpod.
+repository e inserire nel file `.bin/prog2home.sh`, al posto di
+`/workspace/esercitazioni`, la directory dove si vogliono salvare le varie
+esercitazioni.
+
+Per usare i comandi `svolgi`, `verifica`, etc. sulla shell (funziona con
+`bash`, `zsh` e possibilmente altre), usare il comando
+`export PATH=$PATH:/percorso/assoluto/al/repository/.bin`, oppure aggiungere
+il comando al proprio `~/.bashrc` (o analoghi) per rendere il cambiamento permanente.
+
+
 
 Questa modalità è riservata agli studenti già esperti nell'uso degli strumenti
 indicati, ragione per la quale non è previsto alcun supporto ulteriore in caso


### PR DESCRIPTION
Salve,
ho apportato qualche semplice modifica per cercare di rendere più portabili gli script e farli agire su una directory, impostata dall'utente nel file `prog2home.sh`, di modo che sia più immediato farli lavorare sulla propria macchina, qualora uno studente lo desiderasse. Di default dovrebbero comunque funzionare sulle directory di Gitpod. Ho integrato un pezzo di tutorial nell'apposita sezione (già esistente) del README. Spero apprezziate :)